### PR TITLE
Improve timeline and simplify navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
-Thank you for looking into my page. I want to make this useable by others at some point, 
-so I will eventually change the inputs from all of the Component pages to API calls so that anyone can put their own information in.
+Thank you for checking out my portfolio. The site loads project data from JSON
+files so it can be easily extended.
 
-Right now, all you would need to do to change the majority of information is change the JSON files: cardinfo and projects. These hold most of the information on the site.
-You would also need to go change the links in the javascript as well as names, but I imagine if you made it to the github, you knew that.
+## Adding or Editing Projects
+
+Project summaries and timeline entries are stored in
+`public/cardinfo.json`. More detailed data for each project lives in
+`public/projects.json` under the same `id` value.
+
+To add a new project:
+
+1. Append an object to `public/cardinfo.json` with the basic information
+   (`id`, `title`, `year`, `description`, etc.).
+2. Add a matching entry in `public/projects.json` that contains the
+   extended details shown on the single project page.
+
+Once these files are updated the site will display the new project on the
+timeline and the project detail page will be automatically available at
+`/project/<id>`.
+
+The Projects tab has been removed now that the timeline links directly to
+each project.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,7 +90,6 @@ function AppContent() {
           <Route path="/" element={<Layout cards={cards} />} />
           <Route path="/bio" element={<Layout cards={cards}><Bio /></Layout>} />
           <Route path="/timeline" element={<Layout cards={cards}><Timeline /></Layout>} />
-          <Route path="/projects" element={<Layout cards={cards} />} />
           <Route path="/project/:id" element={<Layout cards={cards} />} />
         </Routes>
       </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, ReactNode } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import "../styles/home.css";
-import CardGrid from './CardGrid';
 import ProjectDetail from './ProjectDetail';
 import { getTechCategory } from "../utils/techCategories";
 import '../styles/backButton.css';
@@ -159,8 +158,8 @@ const Layout: React.FC<LayoutProps> = ({ children, cards = [] }) => {
   }, [location.pathname, cardsData]);
 
   const isActive = (path: string) => {
-    if (path === '/projects') {
-      return location.pathname === '/projects' || location.pathname.startsWith('/project/');
+    if (path === '/timeline') {
+      return location.pathname === '/timeline' || location.pathname.startsWith('/project/');
     }
     return location.pathname === path;
   };
@@ -193,12 +192,6 @@ const Layout: React.FC<LayoutProps> = ({ children, cards = [] }) => {
               className={`social-link hat ${isActive('/bio') ? 'active-link' : ''}`}
             >
               Read Bio
-            </Link>
-            <Link
-              to="/projects"
-              className={`social-link hat ${isActive('/projects') ? 'active-link' : ''}`}
-            >
-              View Projects
             </Link>
             <Link
               to="/timeline"
@@ -242,7 +235,6 @@ const Layout: React.FC<LayoutProps> = ({ children, cards = [] }) => {
           {location.pathname === '/' && <TechnologiesSection />}
           {location.pathname === '/bio' && children}
           {location.pathname === '/timeline' && children}
-          {location.pathname === '/projects' && <CardGrid cards={cardsData} />}
           {isProjectDetail && <ProjectDetail cards={projectsData.length > 0 ? projectsData : cardsData} />}
         </div>
       </div>

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import '../styles/timeline.css';
 
 interface Card {
@@ -31,11 +32,11 @@ const Timeline: React.FC = () => {
         {sorted.map(card => (
           <div key={card.id} className="timeline-item">
             <div className="timeline-point" />
-            <div className="timeline-content">
+            <Link to={`/project/${card.id}`} className="timeline-content">
               <span className="timeline-year">{card.year}</span>
               <h3 className="timeline-header">{card.title}</h3>
               {card.description && <p>{card.description}</p>}
-            </div>
+            </Link>
           </div>
         ))}
       </div>

--- a/src/styles/timeline.css
+++ b/src/styles/timeline.css
@@ -29,6 +29,14 @@
   position: relative;
   margin-bottom: 1.5rem;
   padding-left: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  padding: 1rem 1rem 1rem 2rem;
+  transition: background-color 0.2s ease;
+}
+
+.timeline-item:hover {
+  background-color: rgba(255, 255, 255, 0.05);
 }
 
 .timeline-point {
@@ -45,4 +53,11 @@
   font-weight: bold;
   color: #ff5722;
   margin-right: 0.5rem;
+}
+
+.timeline-content {
+  color: inherit;
+  text-decoration: none;
+  display: block;
+  cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- make timeline entries link to project detail pages
- remove Projects tab and route
- refine timeline styles
- document how to add more projects in README

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687859c45fd08332ba5c02dacd9d5147