### PR TITLE
Add GAP Prediction Modeling project

### DIFF
--- a/public/cardinfo.json
+++ b/public/cardinfo.json
@@ -64,5 +64,15 @@
     "results": "Users able to use this world for event planning and practice, our team practiced game mechanics successfully.",
     "link": "/rvm-fob",
     "type": "archived"
+  },
+  {
+    "id": 7,
+    "title": "GAP Prediction Modeling",
+    "description": "Built XGBoost and SARIMAX models to predict Gross Auction Proceeds with near 1% error.",
+    "role": "Solo Data Scientist",
+    "technologies": "Python, XGBoost, SARIMAX, scikit-learn, matplotlib, seaborn",
+    "year": "2025",
+    "results": "Improved forecasting accuracy from 90% to ~99% within 5 sigma",
+    "type": "demo"
   }
 ]

--- a/public/projects.json
+++ b/public/projects.json
@@ -245,5 +245,30 @@
     "duration": "7 months",
     "technologies": "Lua, Roblox Studio",
     "overview": "A roblox world complete with several real-world and in-game replicas to mimic realistic movements for the Roblox game: Jailbreak. My game featured a Bugatti Chiron, Tesla Roadster, and an MH-6 Little Bird helicopter."
+  },
+  {
+    "id": 7,
+    "title": "GAP Prediction Modeling",
+    "subtitle": "Accurate forecasting of Gross Auction Proceeds",
+    "description": "Developed XGBoost and SARIMAX models to forecast auction proceeds with minimal error.",
+    "year": "2025",
+    "client": "Internal Project",
+    "role": "Solo Data Scientist",
+    "duration": "July 2025 (1 month)",
+    "technologies": "Python, XGBoost, SARIMAX, scikit-learn, matplotlib, seaborn",
+    "overview": "Self-taught Python to build machine learning models predicting Gross Auction Proceeds using historical GAP, CCI, and Lots Sold data.",
+    "highlights": [
+      "~1% residual error within 5 sigma",
+      "XGBoost model incorporating multiple lagged factors",
+      "SARIMAX model accounting for company acquisition"
+    ],
+    "challenges": [
+      "Learning Python and libraries from scratch",
+      "Limited historical data for extreme cases"
+    ],
+    "outcomes": [
+      "Forecast accuracy improved from 90% to ~99%",
+      "Established baseline for future predictive analytics"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- add short card entry for GAP prediction project
- include detailed entry in projects.json for same project

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883a4f9cf40833285e570920341f972