### PR TITLE
Add start dates and update bio

### DIFF
--- a/public/bioinfo.json
+++ b/public/bioinfo.json
@@ -29,19 +29,9 @@
     ],
     "experience": [
       {
-        "title": "Owner, Principal Consultant - Signal Surge LLC",
-        "period": "Since May 2024",
-        "description": "Running an IT Consulting firm focused on providing technical solutions and services. See the My Company tab for more."
-      },
-      {
-        "title": "Sergeant - 20th Special Forces Group",
-        "period": "Since May 2021",
-        "description": "Serving as a Signals Intelligence Analyst with deployment experience in Northwest Africa."
-      },
-      {
-        "title": "Information Technology Manager - Levy, Univ of AL",
-        "period": "Since September 2024",
-        "description": "Responsible for maintaining Point-of-Sale services for $5 Million+ of transactions per year"
+        "title": "Data Intern - JJ Kane",
+        "period": "Since June 2025",
+        "description": "Building dashboards for internal customers like Customer Solutions, Management and Sales."
       },
       {
         "title": "Safety Undergraduate Researcher - Engineering Safety",
@@ -52,6 +42,21 @@
         "title": "Teaching Assistant - Univ of AL",
         "period": "January 2025 - May 2025",
         "description": "Assisted in teaching 100+ students the basics of C# and problem solving with code."
+      },
+      {
+        "title": "Information Technology Manager - Levy, Univ of AL",
+        "period": "Since September 2024",
+        "description": "Responsible for maintaining Point-of-Sale services for $5 Million+ of transactions per year"
+      },
+      {
+        "title": "Owner, Principal Consultant - Signal Surge LLC",
+        "period": "Since May 2024",
+        "description": "Running an IT Consulting firm focused on providing technical solutions and services. See the My Company tab for more."
+      },
+      {
+        "title": "Sergeant - 20th Special Forces Group",
+        "period": "Since May 2021",
+        "description": "Serving as a Signals Intelligence Analyst with deployment experience in Northwest Africa."
       }
     ],
     "education": [

--- a/public/cardinfo.json
+++ b/public/cardinfo.json
@@ -5,7 +5,8 @@
     "description": "Credit acceptance prediction platform for PNC Bank's AIS SCLC 2025 challenge.",
     "role": "Team Developer",
     "technologies": "C#, JavaScript, html, CSS, Random Forest",
-    "year": "2024-2025",
+    "year": "Nov 2024 - Feb 2025",
+    "startDate": "2024-11",
     "results": "Contender for the AIS 2025 Fintech challenge. Team project from Nov 2024 to Feb 2025 with a model accuracy just over 70% on a random test set.",
     "link": "/credit",
     "type": "demo"
@@ -16,7 +17,8 @@
     "description": "Platform for teachers to post their music lesson schedule online for students to join. My first school-sanctioned team project where I learned leadership and followership.",
     "role": "Scrum Master/Data Engineer",
     "technologies": "C#, JavaScript, html, MySQL",
-    "year": "2025",
+    "year": "Jan - Apr 2025",
+    "startDate": "2025-01",
     "results": "Client was satisfied with app outcome, and we got a perfect grade in the course.",
     "link": "/freelance-music",
     "type": "demo"
@@ -27,7 +29,8 @@
     "description": "C# CLI that predicts restaurant sales using LightGBM gradient boosting.",
     "role": "Solo Developer",
     "technologies": "C#, LightGBM, Gradient Boosting",
-    "year": "2024",
+    "year": "Nov - Dec 2024",
+    "startDate": "2024-11",
     "results": "Two-week project in Nov–Dec 2024 predicting sales with a maximum 2% error on real data.",
     "link": "/RevPred",
     "type": "demo"
@@ -38,7 +41,8 @@
     "description": "This application was a demo for using AES-256 encryption and one-time pads for a Business Programming course.",
     "role": "Solo Developer",
     "technologies": "C#, AES-256 Encryption, One-Time Pads, JavaScript, html",
-    "year": "2025",
+    "year": "Mar - Apr 2025",
+    "startDate": "2025-03",
     "results": "Prototype used successfully in training with Army Special Forces. Developed from March to April 2025.",
     "link": "/military-comms",
     "type": "archived"
@@ -49,7 +53,8 @@
     "description": "The site you are viewing now. Started in May 2025, converted from JavaScript to TypeScript and includes a backend for logging user interactions (currently disabled).",
     "role": "Full-Stack Developer",
     "technologies": "React, TypeScript, CSS, Responsive Design, C#, ASP.NET",
-    "year": "2025",
+    "year": "May 2025 - Present",
+    "startDate": "2025-05",
     "results": "Created a professional, responsive platform that demonstrates full-stack capability.",
     "link": "/portfolio",
     "type": "live"
@@ -60,7 +65,8 @@
     "description": "Roblox world built during Covid-19 featuring realistic MH-6 Little Bird, Bugatti Chiron, Tesla Roadster and UH-60 Blackhawk.",
     "role": "Solo Developer",
     "technologies": "Lua, Roblox Studio",
-    "year": "2020-2021",
+    "year": "Mar 2020 - Jan 2021",
+    "startDate": "2020-03",
     "results": "Used for event practice from March 2020 to January 2021. Now decommissioned but visitable at https://www.roblox.com/games/5234643173/Red-Velvet-Mafias-Forward-Operating-Base.",
     "link": "/rvm-fob",
     "type": "archived"
@@ -71,7 +77,8 @@
     "description": "Built XGBoost and SARIMAX models to predict auction revenue with near 1% error.",
     "role": "Solo Data Scientist",
     "technologies": "Python, XGBoost, SARIMAX, scikit-learn, matplotlib, seaborn",
-    "year": "2025",
+    "year": "Jul - Aug 2025",
+    "startDate": "2025-07",
     "results": "Improved forecasting accuracy from 90% to ~99% within 5 sigma. Project ran July–August 2025.",
     "type": "demo"
   }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -11,6 +11,7 @@ export interface CardData {
   role?: string;
   technologies?: string;
   year?: string;
+  startDate?: string;
   results?: string;
   type?: string;
 }

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -7,6 +7,7 @@ interface Card {
   id: number;
   title: string;
   year?: string;
+  startDate?: string;
   description?: string;
 }
 
@@ -21,9 +22,9 @@ const Timeline: React.FC = () => {
   }, []);
 
   const sorted = [...cards].sort((a, b) => {
-    const yearA = parseInt(a.year || '0', 10);
-    const yearB = parseInt(b.year || '0', 10);
-    return yearB - yearA;
+    const dateA = a.startDate ? new Date(a.startDate) : new Date(0);
+    const dateB = b.startDate ? new Date(b.startDate) : new Date(0);
+    return dateB.getTime() - dateA.getTime();
   });
 
   return (

--- a/src/styles/bio.css
+++ b/src/styles/bio.css
@@ -352,7 +352,8 @@
 
   .contact-link {
     justify-content: center;
-    max-width: 100%; /* Changed from 80% to 100% for mobile to use full width */
+    max-width: 300px;
+    width: 100%;
   }
 
   /* Adjust header spacing to ensure it doesn't overlap with the back button */

--- a/src/types/CardData.ts
+++ b/src/types/CardData.ts
@@ -7,5 +7,6 @@ export interface CardData {
   role?: string;
   technologies?: string;
   year?: string;
+  startDate?: string;
   results?: string;
 }

--- a/src/utils/techCategories.ts
+++ b/src/utils/techCategories.ts
@@ -11,12 +11,23 @@ export const getTechCategory = (tech: string): string => {
     tech.includes("asp")
   ) {
     return "backend";
-  } else if (tech.includes("mysql") || tech.includes("database")) {
+  } else if (
+    tech.includes("mysql") ||
+    tech.includes("database") ||
+    tech.includes("sql")
+  ) {
     return "database";
   } else if (
     tech.includes("machine learning") ||
     tech.includes("gradient") ||
     tech.includes("random forest") ||
+    tech.includes("xgboost") ||
+    tech.includes("sarimax") ||
+    tech.includes("scikit") ||
+    tech.includes("matplotlib") ||
+    tech.includes("seaborn") ||
+    tech.includes("lightgbm") ||
+    tech.includes("python") ||
     tech.includes("ai")
   ) {
     return "data";
@@ -38,6 +49,8 @@ export const getTechCategory = (tech: string): string => {
     tech.includes("html") ||
     tech.includes("css") ||
     tech.includes("javascript") ||
+    tech.includes("typescript") ||
+    tech.includes("react") ||
     tech.includes("js") ||
     tech.includes("design")
   ) {


### PR DESCRIPTION
## Summary
- add month-based year descriptions and startDate field for sorting
- expand technology categorization and preserve mobile button styles
- include Data Intern role in bio and sort experience by start date
- adjust timeline sorting to use startDate

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68852e00c4948332992afab5a8ff3253