### PR TITLE
Redesign home page with inline bio and timeline

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,101 +1,162 @@
 import "./styles/styles.css";
 import "./styles/home.css";
-import Bio from "./components/Bio";
-import Timeline from "./components/Timeline";
-import { CardData } from "./components/Card";
-import { BrowserRouter as Router, Routes, Route, useLocation } from "react-router-dom";
-import { useState, useEffect } from "react";
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { useEffect, useMemo, useState } from "react";
 import Layout from "./components/Layout";
-import './styles/backButton.css';
+import Home from "./components/Home";
+import { CardData } from "./components/Card";
+import { TechnologyTag } from "./types/Technology";
+import { BioData } from "./types/Bio";
+import { Project } from "./types/Project";
+import { getTechCategory } from "./utils/techCategories";
 
-function AppContent() {
+const fallbackCards: CardData[] = [
+  {
+    id: 1,
+    title: "CrediTrust AI",
+    description:
+      "Credit acceptance prediction platform for PNC Bank's AIS SCLC 2025 challenge.",
+    role: "Team Developer",
+    technologies: "C#, Javascript, html, css, Random Forest",
+    year: "2024-2025",
+    results:
+      "Contender for the AIS 2025 Fintech challenge. Team project from Nov 2024 to Feb 2025 with model accuracy just over 70% on a random test set.",
+  },
+  {
+    id: 2,
+    title: "Freelance Music",
+    description:
+      "Platform for teachers to post their music lesson schedule online for students to join. My first school-sanctioned team project where I learned leadership and followership.",
+    role: "Scrum Master/Data Engineer",
+    technologies: "C#, Javascript, html, MySQL",
+    year: "2025",
+    results:
+      "Client was satisfied with app outcome, and we got a perfect grade in the course.",
+  },
+  {
+    id: 3,
+    title: "Restaurant Revenue ML Model",
+    description: "CLI predicting restaurant sales using LightGBM gradient boosting",
+    role: "Solo Developer",
+    technologies: "C#, Machine Learning, LightGBM, Gradient Boosting",
+    year: "2024",
+    results: "Two-week project completed in Nov–Dec 2024 with 2% error on real sales",
+  },
+  {
+    id: 4,
+    title: "Secure Communications App",
+    description:
+      "Demo application showcasing AES-256 encryption and one-time pads for a Business Programming course.",
+    role: "Solo Developer",
+    technologies: "C#, Rust, AES-256 encryption, Javascript, html",
+    year: "2025",
+    results:
+      "Prototype used successfully in training with Army Special Forces. Developed March–April 2025.",
+  },
+];
+
+const AppContent = () => {
   const [cards, setCards] = useState<CardData[]>([]);
-  const location = useLocation();
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [bioData, setBioData] = useState<BioData | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
-    console.log("Attempting to fetch cardinfo.json...");
+    const fetchJson = async <T,>(path: string): Promise<T> => {
+      const response = await fetch(path);
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      return response.json();
+    };
 
-    fetch("cardinfo.json")
-      .then((response) => {
-        console.log("Response status:", response.status);
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
+    const loadCards = async () => {
+      try {
+        return await fetchJson<CardData[]>("cardinfo.json");
+      } catch (error) {
+        try {
+          return await fetchJson<CardData[]>("movies.json");
+        } catch (fallbackError) {
+          console.error("Unable to load card data", error, fallbackError);
+          return fallbackCards;
         }
-        return response.json();
-      })
-      .then((data) => {
-        console.log("Successfully loaded data:", data);
-        setCards(data);
-      })
-      .catch((error) => {
-        console.error("Error loading from /cardinfo.json:", error);
+      }
+    };
 
-        console.log("Attempting to fetch movies.json as fallback...");
-        fetch("movies.json")
-          .then((response) => {
-            if (!response.ok) {
-              throw new Error(`HTTP error! status: ${response.status}`);
-            }
-            return response.json();
-          })
-          .then((data) => {
-            console.log("Successfully loaded movies.json data:", data);
-            setCards(data);
-          })
-          .catch((fallbackError) => {
-            console.error(
-              "Error loading from fallback movies.json:",
-              fallbackError
-            );
+    const loadProjects = async () => {
+      try {
+        return await fetchJson<Project[]>("projects.json");
+      } catch (error) {
+        console.error("Unable to load project detail data", error);
+        return [];
+      }
+    };
 
-            setCards([
-              {
-                id: 1,
-                title: "Test Project",
-                description:
-                  "This is a test project to see if cards display correctly.",
-                role: "Developer",
-                technologies: "React",
-                year: "2025",
-                results: "Debugging successful",
-              },
-            ]);
-          });
-      });
+    const loadBio = async () => {
+      try {
+        return await fetchJson<BioData>("bioinfo.json");
+      } catch (error) {
+        console.error("Unable to load bio data", error);
+        return null;
+      }
+    };
+
+    const loadData = async () => {
+      setLoading(true);
+      try {
+        const [cardData, projectData, bio] = await Promise.all([
+          loadCards(),
+          loadProjects(),
+          loadBio(),
+        ]);
+
+        setCards(cardData);
+        setProjects(projectData);
+        setBioData(bio);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadData();
   }, []);
 
-  console.log("Current state of cards:", cards);
-  
-  const currentPathname = location.pathname;
-  
-  const isHomePage = currentPathname === '/';
-
-  useEffect(() => {
-    if (isHomePage) {
-      document.body.classList.add('home-page-body');
-    } else {
-      document.body.classList.remove('home-page-body');
-    }
-    
-    return () => {
-      document.body.classList.remove('home-page-body');
-    };
-  }, [isHomePage]);
+  const technologies: TechnologyTag[] = useMemo(() => {
+    const techStrings = cards.flatMap((card) =>
+      card.technologies
+        ? card.technologies.split(",").map((item) => item.trim())
+        : []
+    );
+    const uniqueTechs = Array.from(new Set(techStrings.filter(Boolean)));
+    return uniqueTechs.map((tech, index) => ({
+      id: index + 1,
+      name: tech,
+      category: getTechCategory(tech),
+    }));
+  }, [cards]);
 
   return (
-    <div className={`App ${isHomePage ? 'home-page-layout' : ''}`}>
-      
-      <div className="container">
-        <Routes>
-          <Route path="/" element={<Layout cards={cards} />} />
-          <Route path="/bio" element={<Layout cards={cards}><Bio /></Layout>} />
-          <Route path="/timeline" element={<Layout cards={cards}><Timeline /></Layout>} />
-          <Route path="/project/:id" element={<Layout cards={cards} />} />
-        </Routes>
-      </div>
-    </div>
+    <Routes>
+      <Route
+        path="/"
+        element={
+          <Layout cards={cards} projects={projects}>
+            <Home
+              cards={cards}
+              bioData={bioData}
+              technologies={technologies}
+              loading={loading}
+            />
+          </Layout>
+        }
+      />
+      <Route
+        path="/project/:id"
+        element={<Layout cards={cards} projects={projects} />}
+      />
+    </Routes>
   );
-}
+};
 
 function App() {
   return (

--- a/src/components/Bio.tsx
+++ b/src/components/Bio.tsx
@@ -1,50 +1,20 @@
-import React, { useState, useEffect } from "react";
-import { Mail, Github, Linkedin, MapPin } from "lucide-react";
+import React from "react";
+import { Mail, Github, Linkedin, MapPin, Globe } from "lucide-react";
 import "../styles/bio.css";
 import BackButton from "./BackButton";
+import { BioData } from "../types/Bio";
 
-interface BioData {
-  name: string;
-  title: string;
-  profileImage: string;
-  skills: { name: string; color: string }[];
-  about: string[];
-  experience: { title: string; period: string; description: string }[];
-  technicalSkills: string[];
-  militarySkills: string[];
-  certificates: string[];
-  education: { degree: string; period: string; description: string }[];
-  contact: { type: string; url?: string }[];
+interface BioProps {
+  bioData: BioData | null;
+  showBackButton?: boolean;
+  variant?: "page" | "section";
 }
 
-const Bio: React.FC = () => {
-  const [bioData, setBioData] = useState<BioData | null>(null);
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    console.log("Attempting to fetch bioinfo.json...");
-
-    fetch("bioinfo.json")
-      .then((response) => {
-        console.log("Response status:", response.status);
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-        return response.json();
-      })
-      .then((data) => {
-        console.log("Successfully loaded bio data:", data);
-        setBioData(data);
-        setLoading(false);
-      })
-      .catch((error) => {
-        console.error("Error loading from bioinfo.json:", error);
-        setError("Failed to load bio data. Check console for details.");
-        setLoading(false);
-      });
-  }, []);
-
+const Bio: React.FC<BioProps> = ({
+  bioData,
+  showBackButton = true,
+  variant = "page",
+}) => {
   const getContactIcon = (type: string, size = 18) => {
     switch (type.toLowerCase()) {
       case "github":
@@ -56,23 +26,28 @@ const Bio: React.FC = () => {
       case "location":
         return <MapPin size={size} className="contact-link-icon" />;
       default:
-        return null;
+        return <Globe size={size} className="contact-link-icon" />;
     }
   };
 
-  if (loading) return <div>Loading bio information...</div>;
-  if (error) return <div>{error}</div>;
-  if (!bioData) return <div>No bio information available.</div>;
+  if (!bioData) {
+    return (
+      <div className={`bio-container bio-container--${variant}`}>
+        {showBackButton && <BackButton />}
+        <p className="bio-empty-state">Bio information will be updated soon.</p>
+      </div>
+    );
+  }
 
   return (
-    <div className="bio-container">
-      <BackButton />
-      
+    <div className={`bio-container bio-container--${variant}`}>
+      {showBackButton && <BackButton />}
+
       <div className="bio-header">
         <div className="profile-image-container">
           <img
             src={bioData.profileImage}
-            alt="Profile"
+            alt={`${bioData.name} profile`}
             className="round-image"
           />
         </div>
@@ -80,9 +55,9 @@ const Bio: React.FC = () => {
         <div className="bio-header-content">
           <h1 className="bio-name">{bioData.name}</h1>
           <p className="bio-title">{bioData.title}</p>
-          <div className="skill-tags">
-            {bioData.skills &&
-              bioData.skills.map((skill, index) => (
+          {bioData.skills && bioData.skills.length > 0 && (
+            <div className="skill-tags">
+              {bioData.skills.map((skill, index) => (
                 <span
                   key={index}
                   className={`skill-tag skill-tag-${skill.color}`}
@@ -90,97 +65,121 @@ const Bio: React.FC = () => {
                   {skill.name}
                 </span>
               ))}
-          </div>
+            </div>
+          )}
         </div>
       </div>
 
-      <section className="bio-section">
-        <h2 className="section-title">About Me</h2>
-        {bioData.about.map((paragraph, index) => (
-          <p key={index} className="bio-paragraph">
-            {paragraph}
-          </p>
-        ))}
-      </section>
+      {bioData.about && bioData.about.length > 0 && (
+        <section className="bio-section">
+          <h2 className="section-title">About Me</h2>
+          {bioData.about.map((paragraph, index) => (
+            <p key={index} className="bio-paragraph">
+              {paragraph}
+            </p>
+          ))}
+        </section>
+      )}
 
-      <section className="bio-section">
-        <h2 className="section-title">Experience</h2>
-        {bioData.experience.map((exp, index) => (
-          <div key={index} className="experience-item">
-            <div className="experience-header">
-              <h3 className="experience-title">{exp.title}</h3>
-              <span className="experience-period">{exp.period}</span>
-            </div>
-            <p className="experience-description">{exp.description}</p>
-          </div>
-        ))}
-      </section>
-
-      <section className="bio-section">
-        <h2 className="section-title">Skills</h2>
-        <div className="skills-grid">
-          <div className="skills-column">
-            <h3 className="skills-category">Technical</h3>
-            <ul className="skills-list">
-              {bioData.technicalSkills.map((skill, index) => (
-                <li key={index}>{skill}</li>
-              ))}
-            </ul>
-          </div>
-          <div className="skills-column">
-            <h3 className="skills-category">Military</h3>
-            <ul className="skills-list">
-              {bioData.militarySkills.map((skill, index) => (
-                <li key={index}>{skill}</li>
-              ))}
-            </ul>
-          </div>
-          <div className="skills-column">
-            <h3 className="skills-category">Credentials</h3>
-            <ul className="skills-list">
-              {bioData.certificates.map((skill, index) => (
-                <li key={index}>{skill}</li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      </section>
-
-      <section className="bio-section">
-        <h2 className="section-title">Education</h2>
-        {bioData.education.map((edu, index) => (
-          <div key={index} className="education-item">
-            <div className="education-header">
-              <h3 className="education-degree">{edu.degree}</h3>
-              <span className="education-period">{edu.period}</span>
-            </div>
-            <p className="education-description">{edu.description}</p>
-          </div>
-        ))}
-      </section>
-
-      <section className="bio-section">
-        <h2 className="section-title">Connect With Me!</h2>
-        <div className="contact-container">
-          {bioData.contact.map((contactItem, index) =>
-            contactItem.url ? (
-              <a
-                key={index}
-                href={contactItem.url}
-                className="contact-link"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {getContactIcon(contactItem.type)}
-              </a>
-            ) : (
-              <div key={index} className="contact-link">
-                {getContactIcon(contactItem.type)}
+      {bioData.experience && bioData.experience.length > 0 && (
+        <section className="bio-section">
+          <h2 className="section-title">Experience</h2>
+          {bioData.experience.map((exp, index) => (
+            <div key={index} className="experience-item">
+              <div className="experience-header">
+                <h3 className="experience-title">{exp.title}</h3>
+                <span className="experience-period">{exp.period}</span>
               </div>
-            )
-          )}
-        </div>
-      </section>
+              <p className="experience-description">{exp.description}</p>
+            </div>
+          ))}
+        </section>
+      )}
+
+      {(bioData.technicalSkills || bioData.militarySkills || bioData.certificates) && (
+        <section className="bio-section">
+          <h2 className="section-title">Skills</h2>
+          <div className="skills-grid">
+            {bioData.technicalSkills && bioData.technicalSkills.length > 0 && (
+              <div className="skills-column">
+                <h3 className="skills-category">Technical</h3>
+                <ul className="skills-list">
+                  {bioData.technicalSkills.map((skill, index) => (
+                    <li key={index}>{skill}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {bioData.militarySkills && bioData.militarySkills.length > 0 && (
+              <div className="skills-column">
+                <h3 className="skills-category">Military</h3>
+                <ul className="skills-list">
+                  {bioData.militarySkills.map((skill, index) => (
+                    <li key={index}>{skill}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {bioData.certificates && bioData.certificates.length > 0 && (
+              <div className="skills-column">
+                <h3 className="skills-category">Credentials</h3>
+                <ul className="skills-list">
+                  {bioData.certificates.map((skill, index) => (
+                    <li key={index}>{skill}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        </section>
+      )}
+
+      {bioData.education && bioData.education.length > 0 && (
+        <section className="bio-section">
+          <h2 className="section-title">Education</h2>
+          {bioData.education.map((edu, index) => (
+            <div key={index} className="education-item">
+              <div className="education-header">
+                <h3 className="education-degree">{edu.degree}</h3>
+                <span className="education-period">{edu.period}</span>
+              </div>
+              <p className="education-description">{edu.description}</p>
+            </div>
+          ))}
+        </section>
+      )}
+
+      {bioData.contact && bioData.contact.length > 0 && (
+        <section className="bio-section">
+          <h2 className="section-title">Connect With Me</h2>
+          <div className="contact-container">
+            {bioData.contact.map((contactItem, index) => {
+              const icon = getContactIcon(contactItem.type);
+              const label = contactItem.display || contactItem.type;
+
+              return contactItem.url ? (
+                <a
+                  key={index}
+                  href={contactItem.url}
+                  className="contact-link"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {icon}
+                  <span className="contact-link-label">{label}</span>
+                </a>
+              ) : (
+                <div key={index} className="contact-link">
+                  {icon}
+                  <span className="contact-link-label">{label}</span>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      )}
     </div>
   );
 };

--- a/src/components/FloatingSocialButtons.tsx
+++ b/src/components/FloatingSocialButtons.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Linkedin, PenSquare } from 'lucide-react';
+import '../styles/home.css';
+
+const FloatingSocialButtons: React.FC = () => {
+  return (
+    <div className="floating-social-buttons">
+      <a
+        href="https://www.linkedin.com/in/seanhthomas"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="floating-button floating-button--linkedin"
+        aria-label="Connect on LinkedIn"
+      >
+        <Linkedin size={18} />
+        <span>LinkedIn</span>
+      </a>
+      <a
+        href="https://medium.com/@sean.h.thomas2"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="floating-button floating-button--medium"
+        aria-label="Read on Medium"
+      >
+        <PenSquare size={18} />
+        <span>Medium</span>
+      </a>
+    </div>
+  );
+};
+
+export default FloatingSocialButtons;

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,9 +1,155 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import Bio from './Bio';
+import Timeline from './Timeline';
+import Card, { CardData } from './Card';
+import { BioData } from '../types/Bio';
+import { TechnologyTag } from '../types/Technology';
+import '../styles/home.css';
 
-const Home: React.FC = () => {
+interface HomeProps {
+  cards: CardData[];
+  bioData: BioData | null;
+  technologies: TechnologyTag[];
+  loading?: boolean;
+}
+
+const Home: React.FC<HomeProps> = ({ cards, bioData, technologies, loading }) => {
+  const projectHighlights = useMemo(() => cards.slice(0, 6), [cards]);
+  const linkedinProfile = bioData?.contact?.find(
+    (contact) => contact.type.toLowerCase() === 'linkedin'
+  )?.url;
+
+  const yearsOfExperience = useMemo(() => {
+    const years = cards
+      .map((card) => card.year)
+      .filter((year): year is string => Boolean(year))
+      .map((year) => parseInt(year.slice(0, 4), 10))
+      .filter((year) => !Number.isNaN(year));
+
+    if (!years.length) {
+      return null;
+    }
+
+    const earliest = Math.min(...years);
+    const current = new Date().getFullYear();
+    return current - earliest + 1;
+  }, [cards]);
+
   return (
-    <>
-    </>
+    <div className="home-page">
+      <section className="home-hero">
+        <div className="hero-text">
+          <p className="hero-eyebrow">Hello, I'm {bioData?.name || 'Sean Thomas'}</p>
+          <h1 className="hero-heading">
+            Building human-centered products with disciplined execution.
+          </h1>
+          <p className="hero-description">
+            {bioData?.title || 'Full Stack Developer'} blending software engineering,
+            operational leadership, and data fluency to deliver resilient digital
+            experiences.
+          </p>
+          <div className="hero-actions">
+            <a className="hero-button" href="#projects">
+              Explore projects
+            </a>
+            {linkedinProfile && (
+              <a
+                className="hero-button hero-button--secondary"
+                href={linkedinProfile}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Connect on LinkedIn
+              </a>
+            )}
+          </div>
+        </div>
+
+        <div className="hero-highlights">
+          <div className="highlight-card">
+            <span className="highlight-label">Projects shipped</span>
+            <span className="highlight-value">{cards.length || '—'}</span>
+            <p className="highlight-description">
+              Web apps, machine learning workflows, and secure communication tools.
+            </p>
+          </div>
+          <div className="highlight-card">
+            <span className="highlight-label">Disciplines connected</span>
+            <span className="highlight-value">
+              {technologies.length > 0 ? new Set(technologies.map((tech) => tech.category)).size : '—'}
+            </span>
+            <p className="highlight-description">
+              From frontend polish to backend automation and data intelligence.
+            </p>
+          </div>
+          <div className="highlight-card">
+            <span className="highlight-label">Years in motion</span>
+            <span className="highlight-value">{yearsOfExperience || '—'}</span>
+            <p className="highlight-description">
+              Continuous learning across classrooms, client engagements, and the field.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="home-dual-section">
+        <div className="home-bio-panel">
+          <h2 className="home-section-heading">Bio Snapshot</h2>
+          <Bio bioData={bioData} showBackButton={false} variant="section" />
+        </div>
+        <div className="home-timeline-panel">
+          <h2 className="home-section-heading">Timeline</h2>
+          <Timeline cards={cards} showBackButton={false} variant="section" />
+        </div>
+      </section>
+
+      <section className="home-technologies">
+        <div className="home-technologies-header">
+          <h2 className="home-section-heading">Toolbox</h2>
+          <p className="home-technologies-subtitle">
+            A curated mix of languages, platforms, and services that power my recent work.
+          </p>
+        </div>
+        <div className="home-technologies-grid">
+          {technologies.length > 0 ? (
+            technologies.map((tech) => (
+              <span
+                key={tech.id}
+                className={`tech-chip tech-tag-${tech.category}`}
+              >
+                {tech.name}
+              </span>
+            ))
+          ) : (
+            <p className="home-empty-state">Technologies will be listed soon.</p>
+          )}
+        </div>
+      </section>
+
+      <section className="home-projects" id="projects">
+        <div className="home-projects-header">
+          <h2 className="home-section-heading">Project Highlights</h2>
+          <p>
+            Dive into the initiatives where I bring design sense, business context, and
+            engineering discipline together.
+          </p>
+        </div>
+        {loading && projectHighlights.length === 0 ? (
+          <div className="home-empty-state">Loading project highlights...</div>
+        ) : (
+          <div className="home-project-grid">
+            {projectHighlights.map((card) => (
+              <Card key={card.id} card={card} />
+            ))}
+          </div>
+        )}
+        {cards.length > projectHighlights.length && (
+          <p className="home-projects-note">
+            Looking for more? Every project tile links to a detailed case study.
+          </p>
+        )}
+      </section>
+    </div>
   );
 };
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,241 +1,33 @@
-import React, { useState, useEffect, ReactNode } from 'react';
-import { Link, useLocation } from 'react-router-dom';
-import "../styles/home.css";
+import React, { ReactNode } from 'react';
+import { useLocation } from 'react-router-dom';
+import '../styles/home.css';
 import ProjectDetail from './ProjectDetail';
-import { getTechCategory } from "../utils/techCategories";
-import '../styles/backButton.css';
-
+import FloatingSocialButtons from './FloatingSocialButtons';
 import { CardData } from './Card';
+import { Project } from '../types/Project';
 
 interface LayoutProps {
   children?: ReactNode;
   cards?: CardData[];
+  projects?: Project[];
 }
 
-const Layout: React.FC<LayoutProps> = ({ children, cards = [] }) => {
+const Layout: React.FC<LayoutProps> = ({ children, cards = [], projects = [] }) => {
   const location = useLocation();
-  const [technologies, setTechnologies] = useState<{id: number; name: string; category: string;}[]>([]);
-  const [projectsData, setProjectsData] = useState<CardData[]>([]);
-  const [cardsData, setCardsData] = useState<CardData[]>([]);
-  const [, setLoading] = useState<boolean>(true);
-
-  const extractTechnologies = (cards: CardData[]) => {
-    const techStrings = cards.map(card => card.technologies);
-    
-    const techArray = techStrings.flatMap(tech => 
-      tech ? tech.split(',').map(item => item.trim()) : []
-    );
-    
-    const uniqueTechs = [...new Set(techArray)];
-    
-    const categorizedTechs = uniqueTechs.map((tech, index) => {
-      return {
-        id: index + 1,
-        name: tech,
-        category: getTechCategory(tech)
-      };
-    });
-
-    const categoryOrder = ["frontend", "backend", "database", "data", "security", "service"];
-    
-    return categorizedTechs.sort((a, b) => {
-      const indexA = categoryOrder.indexOf(a.category);
-      const indexB = categoryOrder.indexOf(b.category);
-      return indexA - indexB;
-    });
-  };
-
-  useEffect(() => {
-    setLoading(true);
-    
-    fetch("/cardinfo.json")
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-        return response.json();
-      })
-      .then((data) => {
-        console.log("Successfully loaded card data:", data);
-        setCardsData(data);
-        
-        const techList = extractTechnologies(data);
-        setTechnologies(techList);
-        
-        setLoading(false);
-      })
-      .catch((error) => {
-        console.error("Error loading from /cardinfo.json:", error);
-        
-        if (cards && cards.length > 0) {
-          console.log("Using cards prop as fallback:", cards);
-          setCardsData(cards);
-          
-          const techList = extractTechnologies(cards);
-          setTechnologies(techList);
-        } else {
-          console.log("Using hardcoded fallback data");
-          const fallbackData = [
-            {
-              "id": 1,
-              "title": "CrediTrust AI",
-              "image": "6.jpg",
-              "description": "Credit acceptance prediction platform for PNC Bank's AIS SCLC 2025 challenge.",
-              "role": "Team Developer",
-              "technologies": "C#, Javascript, html, css, Random Forest",
-              "year": "2024-2025",
-              "results": "Contender for the AIS 2025 Fintech challenge. Team project from Nov 2024 to Feb 2025 with model accuracy just over 70% on a random test set.",
-              "link": "/credit",
-              "type": "demo"
-            },
-            {
-              "id": 2,
-              "title": "Freelance Music",
-              "image": "FM Logo.png",
-              "description": "Platform for teachers to post their music lesson schedule online for students to join. My first school-sanctioned team project where I learned leadership and followership.",
-              "role": "Scrum Master/Data Engineer",
-              "technologies": "C#, Javascript, html, MySQL",
-              "year": "2025",
-              "results": "Client was satisfied with app outcome, and we got a perfect grade in the course.",
-              "link": "/freelance-music",
-              "type": "demo"
-            },
-            {
-              "id": 3,
-              "title": "Restaurant Revenue ML Model",
-              "image": "revpred.png",
-              "description": "CLI predicting restaurant sales using LightGBM gradient boosting",
-              "role": "Solo Developer",
-              "technologies": "C#, Machine Learning, LightGBM, Gradient Boosting",
-              "year": "2024",
-              "results": "Two-week project completed in Nov–Dec 2024 with 2% error on real sales",
-              "link": "/RevPred",
-              "type": "demo"
-            },
-            {
-              "id": 4,
-              "title": "Secure Communications App",
-              "image": "5.jpg",
-              "description": "This application was a demo for using AES-256 encryption and one-time pads for a Business Programming course.",
-              "role": "Solo Developer",
-              "technologies": "C#, Rust, AES-256 encryption, Javascript, html",
-              "year": "2025",
-              "results": "Prototype used successfully in training with Army Special Forces. Developed March–April 2025.",
-              "link": "/military-comms",
-              "type": "archived"
-            }
-          ];
-          
-          setCardsData(fallbackData);
-          const techList = extractTechnologies(fallbackData);
-          setTechnologies(techList);
-        }
-        
-        setLoading(false);
-      });
-  }, [cards]);
-
-  useEffect(() => {
-    const isProjectDetail = location.pathname.startsWith('/project/');
-    
-    if (isProjectDetail) {
-      fetch("/projects.json")
-        .then((response) => {
-          if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
-          }
-          return response.json();
-        })
-        .then((data) => {
-          console.log("Successfully loaded project data:", data);
-          setProjectsData(data);
-        })
-        .catch((error) => {
-          console.error("Error loading from /projects.json:", error);
-          setProjectsData(cardsData.length > 0 ? cardsData : []);
-        });
-    }
-  }, [location.pathname, cardsData]);
-
-  const isActive = (path: string) => {
-    if (path === '/timeline') {
-      return location.pathname === '/timeline' || location.pathname.startsWith('/project/');
-    }
-    return location.pathname === path;
-  };
-
   const isProjectDetail = location.pathname.startsWith('/project/');
-
-  const TechnologiesSection = () => (
-    <div className="belly-technologies">
-      <h2 className="tech-heading">Languages and Technologies</h2>
-      <div className="tech-tags">
-        {technologies.map(tech => (
-          <span 
-            key={tech.id} 
-            className={`tech-tag tech-tag-${tech.category}`}
-          >
-            {tech.name}
-          </span>
-        ))}
-      </div>
-    </div>
-  );
+  const projectSource = projects.length > 0 ? projects : cards;
 
   return (
-    <div className="home-container">
-      <div className="tree-layout">
-        <div className="main-card-container">
-          <div className="social-hat">
-            <Link
-              to="/bio"
-              className={`social-link hat ${isActive('/bio') ? 'active-link' : ''}`}
-            >
-              Read Bio
-            </Link>
-            <Link
-              to="/timeline"
-              className={`social-link hat ${isActive('/timeline') ? 'active-link' : ''}`}
-            >
-              Timeline
-            </Link>
-          </div>
-          
-          <div className="name-card-with-ears">
-            <div className="ear left-ear">
-              <a 
-                href="https://medium.com/@sean.h.thomas2" 
-                target="_blank" 
-                rel="noopener noreferrer"
-                className="ear-link"
-              >
-                <span className="vertical-text">Medium</span>
-              </a>
-            </div>
-            
-            <div className="name-container">
-              <h1 className="name">Sean Thomas</h1>
-              <h2 className="title">Full Stack Developer</h2>
-            </div>
-            
-            <div className="ear right-ear">
-              <a 
-                href="https://linkedin.com/in/seanhthomas" 
-                target="_blank" 
-                rel="noopener noreferrer"
-                className="ear-link"
-              >
-                <span className="vertical-text">LinkedIn</span>
-              </a>
-            </div>
-          </div>
-        </div>
-
-        <div className="content-area">
-          {location.pathname === '/' && <TechnologiesSection />}
-          {location.pathname === '/bio' && children}
-          {location.pathname === '/timeline' && children}
-          {isProjectDetail && <ProjectDetail cards={projectsData.length > 0 ? projectsData : cardsData} />}
+    <div className="layout-shell">
+      <FloatingSocialButtons />
+      <div className="layout-surface">
+        <div className="layout-gradient" />
+        <div className="layout-content container">
+          {isProjectDetail ? (
+            <ProjectDetail cards={projectSource} />
+          ) : (
+            children
+          )}
         </div>
       </div>
     </div>

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -3,23 +3,7 @@ import { useParams } from "react-router-dom";
 import "../styles/projects.css";
 import { getTechCategory } from "../utils/techCategories";
 import BackButton from "./BackButton";
-import { CardData } from "./Card";
-
-interface Project extends CardData {
-  subtitle?: string;
-  client?: string;
-  duration?: string;
-  highlights?: string[];
-  challenges?: string[];
-  features?: { title: string; description: string }[];
-  approach?: { step: string; title: string; description: string }[];
-  roleDetails?: {
-    scrumMaster?: string[];
-    dataEngineer?: string[];
-  };
-  outcomes?: string[];
-  team?: { name: string; role: string; linkedIn: string }[];
-}
+import { Project } from "../types/Project";
 
 interface ProjectDetailProps {
   cards?: Project[];

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import BackButton from './BackButton';
 import '../styles/timeline.css';
 
-interface Card {
+export interface TimelineCard {
   id: number;
   title: string;
   year?: string;
@@ -11,37 +11,46 @@ interface Card {
   description?: string;
 }
 
-const Timeline: React.FC = () => {
-  const [cards, setCards] = useState<Card[]>([]);
+interface TimelineProps {
+  cards?: TimelineCard[];
+  showBackButton?: boolean;
+  variant?: 'page' | 'section';
+}
 
-  useEffect(() => {
-    fetch('/cardinfo.json')
-      .then(res => res.json())
-      .then(data => setCards(data))
-      .catch(() => setCards([]));
-  }, []);
+const Timeline: React.FC<TimelineProps> = ({
+  cards = [],
+  showBackButton = true,
+  variant = 'page',
+}) => {
+  const sorted = useMemo(() => {
+    return [...cards].sort((a, b) => {
+      const dateA = a.startDate ? new Date(a.startDate) : new Date(0);
+      const dateB = b.startDate ? new Date(b.startDate) : new Date(0);
+      return dateB.getTime() - dateA.getTime();
+    });
+  }, [cards]);
 
-  const sorted = [...cards].sort((a, b) => {
-    const dateA = a.startDate ? new Date(a.startDate) : new Date(0);
-    const dateB = b.startDate ? new Date(b.startDate) : new Date(0);
-    return dateB.getTime() - dateA.getTime();
-  });
+  const containerClass = `timeline-container timeline-container--${variant}`;
 
   return (
-    <div className="timeline-container">
-      <BackButton />
+    <div className={containerClass}>
+      {showBackButton && <BackButton />}
       <h1 className="timeline-title">Project Timeline</h1>
       <div className="timeline">
-        {sorted.map(card => (
-          <div key={card.id} className="timeline-item">
-            <div className="timeline-point" />
-            <Link to={`/project/${card.id}`} className="timeline-content">
-              <span className="timeline-year">{card.year}</span>
-              <h3 className="timeline-header">{card.title}</h3>
-              {card.description && <p>{card.description}</p>}
-            </Link>
-          </div>
-        ))}
+        {sorted.length === 0 ? (
+          <div className="timeline-empty">Project milestones will appear here soon.</div>
+        ) : (
+          sorted.map(card => (
+            <div key={card.id} className="timeline-item">
+              <div className="timeline-point" />
+              <Link to={`/project/${card.id}`} className="timeline-content">
+                <span className="timeline-year">{card.year}</span>
+                <h3 className="timeline-header">{card.title}</h3>
+                {card.description && <p>{card.description}</p>}
+              </Link>
+            </div>
+          ))
+        )}
       </div>
     </div>
   );

--- a/src/styles/bio.css
+++ b/src/styles/bio.css
@@ -1,18 +1,32 @@
 /* Bio Page Specific Styles - Space Theme */
 
 .bio-container {
-  width: 100%; /* Changed from max-width: 900px to width: 100% */
+  width: 100%;
   margin: 0 auto;
   padding: 5rem 2rem 2rem;
   position: relative;
   z-index: 1;
-  box-sizing: border-box; /* Include padding in width calculation */
+  box-sizing: border-box;
+}
+
+.bio-container--section {
+  padding: 0;
 }
 
 .back-button:hover {
   background: #ff5722;
   color: white;
   box-shadow: 0 4px 12px rgba(255, 87, 34, 0.3);
+}
+
+.bio-empty-state {
+  margin: 0;
+  padding: 1.5rem;
+  text-align: center;
+  color: rgba(233, 235, 255, 0.85);
+  background: rgba(16, 20, 40, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
 }
 
 /* Header Section */
@@ -30,6 +44,14 @@
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
   width: 100%; /* Ensure full width */
   box-sizing: border-box; /* Include padding in width calculation */
+}
+
+.bio-container--section .bio-header {
+  background: rgba(16, 20, 40, 0.85);
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: none;
+  padding: 1.75rem;
+  margin-bottom: 1.5rem;
 }
 
 @media (min-width: 768px) {
@@ -139,6 +161,18 @@
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
   width: 100%; /* Ensure full width */
   box-sizing: border-box; /* Include padding in width calculation */
+}
+
+.bio-container--section .bio-section {
+  margin-bottom: 1.25rem;
+  background: rgba(16, 20, 40, 0.85);
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: none;
+  padding: 1.5rem;
+}
+
+.bio-container--section .bio-section:last-of-type {
+  margin-bottom: 0;
 }
 
 .section-title {

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -1,322 +1,351 @@
 @import "./technology-tags.css";
 
-.home-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  min-height: 100vh;
-  padding: 2rem;
-  color: white;
-  text-align: center;
+.layout-shell {
   position: relative;
-  z-index: 1;
-  width: 100%; /* Changed from auto to 100% */
-  box-sizing: border-box; /* Add this to include padding in width calculation */
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(47, 98, 226, 0.25), transparent 55%),
+    radial-gradient(circle at 20% 20%, rgba(255, 87, 34, 0.18), transparent 60%),
+    #050510;
+  overflow-x: hidden;
 }
 
-.tree-layout {
+.layout-surface {
+  position: relative;
+  min-height: 100vh;
+  padding: 4rem 0 6rem;
+}
+
+.layout-gradient {
+  position: absolute;
+  inset: 0;
+  max-width: 1400px;
+  margin: 0 auto;
+  background: linear-gradient(180deg, rgba(255, 87, 34, 0.4) 0%, rgba(7, 16, 38, 0) 70%);
+  filter: blur(120px);
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.layout-content {
+  position: relative;
+  z-index: 2;
+}
+
+.home-page {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  width: 100%;
-  /* Removed max-width to allow full expansion */
-  max-width: calc(100% - 4px); /* Ensure proper edges */
+  gap: 4rem;
 }
 
-/* Main card container with hat and ears */
-.main-card-container {
+.home-hero {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  width: 100%;
-  /* Removed max-width to allow full expansion */
-  max-width: calc(100% - 2px); /* Ensure proper edges */
+  gap: 2.5rem;
+  padding: 2.5rem;
+  border-radius: 24px;
+  background: rgba(12, 16, 32, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 25px 60px rgba(7, 10, 22, 0.45);
+  backdrop-filter: blur(16px);
 }
 
-/* Social links as hat */
-.social-hat {
+.hero-text {
   display: flex;
-  justify-content: center;
-  gap: 1rem;
-  width: 100%;
-  flex-wrap: wrap; /* Allow wrapping on smaller screens */
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
-.social-link {
-  display: block;
-  padding: 0.8rem 1.5rem;
-  color: white;
-  text-decoration: none;
-  background: rgba(18, 18, 20, 0.8);
-  transition: all 0.3s ease;
-  font-weight: 500;
-  backdrop-filter: blur(5px);
-  border: 1px solid rgba(40, 40, 45, 0.8);
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
-  flex: 1; /* Allow links to grow */
-  min-width: 80px; /* Reduced from 120px */
-  margin-bottom: auto;
-  text-align: center;
+.hero-eyebrow {
+  font-size: 0.85rem;
+  letter-spacing: 0.28rem;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+  margin: 0;
 }
 
-.social-link:hover {
-  background: #ff5722;
-  color: white;
-  box-shadow: 0 6px 20px rgba(255, 87, 34, 0.4);
-}
-
-/* Name card with attached ears */
-.name-card-with-ears {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  margin: auto auto;
-  max-width: calc(100% - 2px); /* Ensure it doesn't overflow */
-}
-
-/* Both left and right ears */
-.left-ear, .right-ear {
-  width: clamp(30px, 5vw, 50px); /* Standard ear width */
-}
-
-.name-container {
-  background: rgba(18, 18, 20, 0.8);
-  backdrop-filter: blur(10px);
-  border: 1px solid #ff5722;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-  padding: 2.5rem 3rem;
-  flex: 1;
-  /* Removed max-width to allow full expansion */
-}
-
-.name {
-  font-size: clamp(2rem, 5vw, 4rem); /* Responsive font size */
-  margin-bottom: 0.5rem;
+.hero-heading {
+  font-size: clamp(2.4rem, 4vw, 3.5rem);
   font-weight: 700;
-  text-shadow: 0 0 20px rgba(255, 255, 255, 0.3);
-  letter-spacing: 2px;
+  margin: 0;
   color: #ffffff;
+  line-height: 1.2;
 }
 
-.title {
-  font-size: clamp(1.2rem, 3vw, 1.8rem); /* Responsive font size */
-  font-weight: 400;
-  color: #ff5722;
-  margin-top: 0;
+.hero-description {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: rgba(233, 235, 255, 0.85);
+  margin: 0;
 }
 
-/* Ear styling */
-.ear {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(18, 18, 20, 0.8);
-  border: 1px solid #ff5722;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
-  width: clamp(30px, 5vw, 50px); /* Responsive width */
-  z-index: 8;
-  border-bottom: none;
-}
-
-.ear-link {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  width: 100%;
-  color: white;
-  text-decoration: none;
-  transition: all 0.3s ease;
-}
-
-.ear-link:hover {
-  background: #ff5722;
-  color: white;
-}
-
-.vertical-text {
-  writing-mode: vertical-lr;
-  text-orientation: mixed;
-  transform: rotate(180deg);
-  font-weight: 500;
-  letter-spacing: 1px;
-  padding: 0.5rem;
-  font-size: clamp(0.7rem, 1.5vw, 1rem); /* Responsive font size */
-}
-
-.hat {
-  border: 1px solid #ff5722;
-  z-index: 20;
-}
-
-.right-ear .vertical-text {
-  transform: none;
-}
-
-/* Active link styling */
-.active-link {
-  background: #ff5722;
-  color: white;
-  box-shadow: 0 6px 20px rgba(255, 87, 34, 0.4);
-}
-
-/* Content area styling */
-.content-area {
-  background: rgba(18, 18, 20, 0.8);
-  backdrop-filter: blur(10px);
-  border: 1px solid #ff5722;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-  width: 100%;
-  max-width: calc(100% - 2px); /* Ensure proper alignment */
-  margin-top: -2px; /* Connect with name card above */
-  padding: 2rem;
-  min-height: 300px; /* Give content some minimum height */
-  z-index: 10;
-  box-sizing: border-box; /* Include padding in width calculation */
-}
-
-/* Technologies Section */
-.belly-technologies {
-  margin: 2rem 0;
-  padding: 1.5rem;
-  text-align: center;
-  border: #ff5722;
-  z-index: 10;
-  width: 100%;
-  box-sizing: border-box; /* Include padding in width calculation */
-}
-
-.tech-heading {
-  font-size: clamp(1.2rem, 3vw, 1.75rem); /* Responsive font size */
-  margin-bottom: 1.5rem;
-  text-align: center;
-  color: #fff;
-  border-bottom: 2px solid #ff5722;
-  padding-bottom: 0.5rem;
-  display: inline-block;
-  left: 50%;
-}
-
-.tech-tags {
+.hero-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 1rem;
+}
+
+.hero-button {
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
+  padding: 0.85rem 1.8rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  color: #050510;
+  background: #ff784d;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  box-shadow: 0 15px 35px rgba(255, 120, 77, 0.35);
 }
 
-/* Belly content container */
-.belly-content {
-  width: 100%;
-  position: relative;
-  padding: 0rem;
-  color: #e0e0e0;
-  box-sizing: border-box; /* Include padding in width calculation */
+.hero-button:hover {
+  transform: translateY(-2px);
+  background: #ff8f68;
 }
 
-.back-button:hover {
-  background: #ff5722;
-  color: white;
-  box-shadow: 0 4px 12px rgba(255, 87, 34, 0.3);
-}
-
-/* Loading and error messages */
-.loading-message,
-.error-message {
-  text-align: center;
-  padding: 3rem 1rem;
-  font-size: 1.1rem;
-}
-
-.error-message {
-  color: #ff5722;
-}
-
-.belly-content .project-title {
-  font-size: clamp(1.5rem, 4vw, 2.2rem); /* Responsive font size */
+.hero-button--secondary {
+  background: transparent;
   color: #ffffff;
-  margin-bottom: 0.5rem;
-  text-shadow: 0 0 10px rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  box-shadow: none;
 }
 
-.belly-content .project-subtitle {
-  font-size: clamp(0.9rem, 2vw, 1.2rem); /* Responsive font size */
-  color: #ff5722;
-  margin-bottom: 2rem;
+.hero-button--secondary:hover {
+  background: rgba(255, 255, 255, 0.1);
 }
 
-.belly-content .project-section {
-  margin-bottom: 2.5rem;
+.hero-highlights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.5rem;
 }
 
-/* Small screen adjustments */
-@media (max-width: 480px) {
-  .home-container {
-    width: 100%;
-    padding: 0.5rem;
-    border: none;
+.highlight-card {
+  background: rgba(16, 20, 40, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.highlight-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.highlight-value {
+  font-size: 2.3rem;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.highlight-description {
+  margin: 0;
+  color: rgba(233, 235, 255, 0.7);
+  line-height: 1.5;
+}
+
+.home-dual-section {
+  display: grid;
+  gap: 2rem;
+}
+
+.home-bio-panel,
+.home-timeline-panel {
+  background: rgba(12, 16, 32, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: 0 20px 45px rgba(7, 10, 22, 0.35);
+  backdrop-filter: blur(12px);
+}
+
+.home-section-heading {
+  font-size: 1.6rem;
+  margin: 0 0 1.5rem;
+  color: #ffffff;
+}
+
+.home-technologies {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  background: rgba(12, 16, 32, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 20px 45px rgba(7, 10, 22, 0.35);
+  backdrop-filter: blur(12px);
+}
+
+.home-technologies-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.home-technologies-subtitle {
+  margin: 0;
+  color: rgba(233, 235, 255, 0.75);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.home-technologies-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.tech-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.6rem 1.1rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  text-transform: capitalize;
+}
+
+.home-projects {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  background: rgba(12, 16, 32, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 20px 45px rgba(7, 10, 22, 0.35);
+  backdrop-filter: blur(12px);
+}
+
+.home-projects-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: rgba(233, 235, 255, 0.85);
+  font-size: 1.05rem;
+}
+
+.home-project-grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.home-projects-note {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(233, 235, 255, 0.75);
+}
+
+.home-empty-state {
+  margin: 0;
+  padding: 1.5rem;
+  border-radius: 16px;
+  background: rgba(16, 20, 40, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  text-align: center;
+  color: rgba(233, 235, 255, 0.8);
+}
+
+.floating-social-buttons {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 30;
+}
+
+.floating-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-decoration: none;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  color: #ffffff;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  background: rgba(22, 25, 45, 0.85);
+  box-shadow: 0 12px 30px rgba(8, 12, 30, 0.45);
+}
+
+.floating-button:hover {
+  transform: translateY(-2px);
+  background: rgba(32, 36, 60, 0.95);
+}
+
+.floating-button--linkedin {
+  background: rgba(10, 102, 194, 0.85);
+  border-color: rgba(10, 102, 194, 0.4);
+}
+
+.floating-button--linkedin:hover {
+  background: rgba(10, 102, 194, 0.95);
+}
+
+.floating-button--medium {
+  background: rgba(29, 185, 84, 0.8);
+  border-color: rgba(29, 185, 84, 0.4);
+}
+
+.floating-button--medium:hover {
+  background: rgba(29, 185, 84, 0.95);
+}
+
+@media (min-width: 992px) {
+  .home-hero {
+    flex-direction: row;
+    align-items: center;
   }
-  
-  .name-container {
-    padding: 1.5rem 1rem;
+
+  .hero-text,
+  .hero-highlights {
+    flex: 1;
   }
-  
-  .content-area {
-    padding: 1.5rem 1rem;
-  }
-  
-  .ear-link {
-    padding: 0.6rem 1rem;
-    font-size: 0.9rem;
-  }
-  
-  .social-link, .hat-link {
-    padding: 0.6rem 1rem;
-    min-width: 60px;
-    font-size: 0.9rem;
-  }
-  
-  .social-hat, .hat {
-    gap: 0.5rem;
-    width: calc(100% - 2px); /* Ensure proper alignment with other elements */
-  }
-  
-  /* Adjust project hero spacing on mobile */
-  .belly-content .project-hero {
-    margin-top: 3.5rem; /* Less spacing needed on smaller screens */
+
+  .home-dual-section {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-/* Ultra-small screen adjustments */
-@media (max-width: 360px) {
-  .home-container {
-    padding: 0.25rem;
+@media (max-width: 768px) {
+  .layout-surface {
+    padding: 3rem 0 4rem;
   }
-  
-  .name-container {
-    padding: 1rem 0.5rem;
+
+  .home-hero,
+  .home-bio-panel,
+  .home-timeline-panel,
+  .home-technologies,
+  .home-projects {
+    padding: 1.75rem;
   }
-  
-  .content-area {
-    padding: 1rem 0.5rem;
+
+  .floating-social-buttons {
+    right: 1rem;
+    bottom: 1.5rem;
   }
-  
-  .social-link, .hat-link, .ear-link {
-    padding: 0.5rem 0.8rem;
-    min-width: 50px;
-    font-size: 0.85rem;
-  }
-  
-  .name {
-    font-size: clamp(1.5rem, 5vw, 2.5rem);
-  }
-  
-  .title {
-    font-size: clamp(1rem, 3vw, 1.2rem);
-  }
-  
-  /* Adjust project hero spacing on very small screens */
-  .belly-content .project-hero {
-    margin-top: 3rem; /* Even less spacing on very small screens */
+}
+
+@media (max-width: 540px) {
+  .floating-social-buttons {
+    position: static;
+    flex-direction: row;
+    justify-content: center;
+    margin-top: 2rem;
   }
 }

--- a/src/styles/timeline.css
+++ b/src/styles/timeline.css
@@ -5,14 +5,29 @@
   color: #ffffff;
 }
 
+.timeline-container--section {
+  padding: 0;
+  max-width: none;
+}
+
 .timeline-title {
   text-align: center;
   margin-bottom: 2rem;
 }
 
+.timeline-container--section .timeline-title {
+  text-align: left;
+  margin-bottom: 1.5rem;
+}
+
 .timeline {
   position: relative;
   margin-left: 1rem;
+  padding-left: 1.5rem;
+}
+
+.timeline-container--section .timeline {
+  margin-left: 0;
 }
 
 .timeline::before {
@@ -23,35 +38,42 @@
   bottom: 0;
   width: 2px;
   background: #ff5722;
+  opacity: 0.6;
+}
+
+.timeline-container--section .timeline::before {
+  left: 2px;
 }
 
 .timeline-item {
   position: relative;
   margin-bottom: 1.5rem;
-  padding-left: 2rem;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 4px;
-  padding: 1rem 1rem 1rem 2rem;
-  transition: background-color 0.2s ease;
+  padding: 1.1rem 1.25rem 1.1rem 2.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+  background: rgba(16, 20, 40, 0.8);
+  transition: transform 0.2s ease, background 0.2s ease;
 }
 
 .timeline-item:hover {
-  background-color: rgba(255, 255, 255, 0.05);
+  background: rgba(22, 26, 50, 0.9);
+  transform: translateX(4px);
 }
 
 .timeline-point {
   position: absolute;
-  left: -6px;
-  top: 0.25rem;
+  left: -12px;
+  top: 1.2rem;
   width: 12px;
   height: 12px;
   border-radius: 50%;
-  background: #ff5722;
+  background: #ff784d;
+  box-shadow: 0 0 12px rgba(255, 120, 77, 0.6);
 }
 
 .timeline-year {
   font-weight: bold;
-  color: #ff5722;
+  color: #ff784d;
   margin-right: 0.5rem;
 }
 
@@ -60,4 +82,13 @@
   text-decoration: none;
   display: block;
   cursor: pointer;
+}
+
+.timeline-empty {
+  color: rgba(233, 235, 255, 0.75);
+  background: rgba(16, 20, 40, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  padding: 1.25rem;
+  text-align: center;
 }

--- a/src/types/Bio.ts
+++ b/src/types/Bio.ts
@@ -1,0 +1,36 @@
+export interface BioSkill {
+  name: string;
+  color: string;
+}
+
+export interface BioExperience {
+  title: string;
+  period: string;
+  description: string;
+}
+
+export interface BioEducation {
+  degree: string;
+  period: string;
+  description: string;
+}
+
+export interface BioContact {
+  type: string;
+  url?: string;
+  display?: string;
+}
+
+export interface BioData {
+  name: string;
+  title: string;
+  profileImage: string;
+  about?: string[];
+  skills?: BioSkill[];
+  experience?: BioExperience[];
+  technicalSkills?: string[];
+  militarySkills?: string[];
+  certificates?: string[];
+  education?: BioEducation[];
+  contact?: BioContact[];
+}

--- a/src/types/Project.ts
+++ b/src/types/Project.ts
@@ -1,0 +1,17 @@
+import { CardData } from "../components/Card";
+
+export interface Project extends CardData {
+  subtitle?: string;
+  client?: string;
+  duration?: string;
+  highlights?: string[];
+  challenges?: string[];
+  features?: { title: string; description: string }[];
+  approach?: { step: string; title: string; description: string }[];
+  roleDetails?: {
+    scrumMaster?: string[];
+    dataEngineer?: string[];
+  };
+  outcomes?: string[];
+  team?: { name: string; role: string; linkedIn: string }[];
+}

--- a/src/types/Technology.ts
+++ b/src/types/Technology.ts
@@ -1,0 +1,5 @@
+export interface TechnologyTag {
+  id: number;
+  name: string;
+  category: string;
+}


### PR DESCRIPTION
## Summary
- centralize portfolio data loading in App and streamline routing for the redesigned home view
- rebuild the home screen with hero, inline bio/timeline sections, refreshed styling, and floating social buttons
- add reusable typing for bio/projects and update shared components for embedded display

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dae6f2fa748332b69bd3c4dd271873